### PR TITLE
[HOT1: 2021(1)] Convert currency from RM to B$

### DIFF
--- a/hot01_2021(1).c
+++ b/hot01_2021(1).c
@@ -98,6 +98,9 @@ int main(void){
         printf("\n Not applicable for collecting coins and cashback\n");
         strcpy(shopDescription, "Not via Cash Back Channel/Shop Pi");}
 
+    //convert MYR to BND
+    priceBND=priceMYR/3.07;
+
     printf("\n Shopping channel and shop    : %s", shopDescription);
     printf("\n Purchased item               : %s", itemName);
     printf("\n Number of unit               : %d", itemQuantity);


### PR DESCRIPTION
Convert Malaysian Ringgit (RM) to Brunei Dollar (B$) by using provided exchange rate as B$1 = RM3.07.